### PR TITLE
Correct sequencing of flow routing calculations

### DIFF
--- a/src/daily_calculation.F90
+++ b/src/daily_calculation.F90
@@ -220,7 +220,7 @@ contains
         !       is enabled.
 
         ! rejected net_infiltration + runoff will be routed downslope if routing option is turned on
-        call cells%calc_routing( index=indx )
+        call cells%calc_routing( index=jndx )  !use jndx instead of indx for correct order of flow routing calculations
 
       end associate
 


### PR DESCRIPTION
At line 223 of daily_calculation.F90, correct the sequencing of flow routing by changing from

```fortran
call cells%calc_routing( index=indx )
```

to

```fortran
call cells%calc_routing( index=jndx )
```

Resolves issue #28